### PR TITLE
Support multiple connections per host

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,8 @@ These can be configured from the application configuration file following OTP st
 | keyspace               | `"ecql"`           | Keyspace to be used by all connections & streams |
 | replication_strategy   | `"SimpleStrategy"` | Replication strategy to be used if keyspace does not yet exists and needs to be created. |
 | replication_factor     | `2`                | Replication factor to be used if keyspace does not yet exists and needs to be created. |
-| streams_per_connection | `100`              | Streams to open to each Server in the cluster |
+| streams_per_connection | `100`              | Streams to open for every Connection |
+| connections_per_host   | `1`                | Connections to open to each Server in the cluster |
 
 # Todo List
 

--- a/src/ecql.erl
+++ b/src/ecql.erl
@@ -189,9 +189,7 @@ autodiscover_peers() ->
 %%------------------------------------------------------------------------------
 repair_connection_pool(OldPoolTuple, Configuration) ->
     ConnectionsPerHost = proplists:get_value(connections_per_host, Configuration, 1)
-   ,HostsList = lists:flatmap(fun(_) -> lists:map(fun(HostAddress) -> HostAddress end,
-                                                proplists:get_value(hosts, Configuration, []))
-                             end,
+   ,HostsList = lists:flatmap(fun(_) -> proplists:get_value(hosts, Configuration, []) end,
                              lists:seq(1, ConnectionsPerHost))
   ,NewHosts = sets:from_list(lists:zip(HostsList, lists:seq(1, length(HostsList))))
   ,OldPool = tuple_to_list(OldPoolTuple)

--- a/src/ecql.erl
+++ b/src/ecql.erl
@@ -189,7 +189,7 @@ autodiscover_peers() ->
 %%------------------------------------------------------------------------------
 repair_connection_pool(OldPoolTuple, Configuration) ->
     ConnectionsPerHost = proplists:get_value(connections_per_host, Configuration, 1)
-   ,HostsList = lists:flatmap(fun(_)-> lists:map(fun(HostAddress) -> HostAddress end,
+   ,HostsList = lists:flatmap(fun(_) -> lists:map(fun(HostAddress) -> HostAddress end,
                                                 proplists:get_value(hosts, Configuration, []))
                              end,
                              lists:seq(1, ConnectionsPerHost))


### PR DESCRIPTION
Introduce a new configuration parameter `connections_per_host`. By default there's 1 connection per host.